### PR TITLE
Dockerizing the backend and making a compose file

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM openjdk:17-jdk
+
+COPY ./target/backend-0.0.1-SNAPSHOT.jar backend.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java","-jar","backend.jar"]

--- a/backend/compose.yml
+++ b/backend/compose.yml
@@ -1,0 +1,32 @@
+version: '3'
+
+services:
+
+  app:
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:mysql://db:3306/courses 
+      - SPRING_DATASOURCE_USERNAME=skillsync
+      - SPRING_DATASOURCE_PASSWORD=skillsync
+    depends_on:
+      - db
+
+  db:
+    image: mysql:latest
+    environment:
+      - MYSQL_DATABASE=courses
+      - MYSQL_USER=skillsync
+      - MYSQL_PASSWORD=skillsync
+      - MYSQL_ROOT_PASSWORD=root
+    volumes:
+      - db-data:/var/lib/mysql
+
+volumes:
+  db-data:
+
+#courses is the name of the database.
+#skillsync is the username and password for the mysql database container.


### PR DESCRIPTION
I have made a **Dockerfile** in the backend which contains the instructions for creating the docker image for the backend application.
It will build the docker image using the backend jar file that needs to be made before this using _".\mvnw clean install"_ in the command prompt in the backend folder. This will create the jar file. After this the Dockerfile can create the image successfully.

I also added a **compose.yml** file which defines the services for the mysql and the backend app. Using this file we can build and run the backend app in the docker. For this we have to run these two docker commands in the order mentioned:
1. _"docker-compose up db"_
2. _"docker-compose up"_ 
